### PR TITLE
Streamline heartbeat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Simple library (with reference Python implementation) to do discovery
 on top of zeromq messaging. This is a modification of the ROS 2.0 zmq
 prototype to implement messaging + discovery via zmq with serialization
-handled through JSON or BSON (if available).  Also provides topic  synchronization capability through the `get_listeners` method.  
+handled through JSON or BSON (if available).  Also provides topic  synchronization capability through the `get_listeners` method.
 
 Raw message definitions:
 
@@ -21,27 +21,20 @@ Raw message definitions:
 
   * subscription (SUB):
     * HDR (TYPE = 2)
-    * (null body)
-
-  * synchronization (SYN):
-    * HDR (TYPE = 2)
-    * (null body)
     * ADDRESSLENGTH: 2 bytes; length, in bytes, of ADDRESS
-    * PUB_ADDRESS: one valid ZeroMQ address (e.g., "tcp://10.0.0.1:6000")
-    * ADDRESSLENGTH: 2 bytes; length, in bytes, of ADDRESS
-    * SUB_ADDRESS: one valid ZeroMQ address (e.g., "tcp://10.0.0.1:6000")
+    * ADDRESS: one valid ZeroMQ address (e.g., "tcp://10.0.0.1:6000")
 
 
 ZeroMQ message definitions (for which we will let zeromq handle framing):
 
   * publication (PUB) multipart messages, with the following parts:
     * TOPIC (placed first to facilitate filtering)
-    * BODY: opaque bytes, where the first byte is PUB_MSG or PUB_HB
+    * BODY: opaque bytes
 
 
 Defaults and conventions:
 
-  * Default port for SUB and ADV messages: 11312
+  * Default port for Broadcast messages: 11312
   * By convention, Raw messages are sent to a broadcast address.
   * In raw messages, all integers are sent little-endian
 

--- a/dzmq/core.py
+++ b/dzmq/core.py
@@ -261,6 +261,11 @@ class DZMQ(object):
         self.poller.register(self.bcast_recv, zmq.POLLIN)
         self.poller.register(self.sub_socket, zmq.POLLIN)
 
+        # wait for the pub socket to start up
+        poller = zmq.Poller()
+        poller.register(self.pub_socket, zmq.POLLOUT)
+        poller.poll()
+
         self._last_hb = 0
         self._adv_queue = []
         self._sub_queue = []

--- a/dzmq/tests/test_dzmq.py
+++ b/dzmq/tests/test_dzmq.py
@@ -67,6 +67,7 @@ class TestPubSub(object):
         self.pub.publish('hey_hey', payload)
         self.pub.publish('boo_boo', payload)
         self.sub.spinOnce()
+        self.sub.spinOnce()
 
         # check the output
         output = self.get_log()
@@ -95,6 +96,7 @@ class TestPubSub(object):
         self.pub.publish('yeah_yeah', payload)
 
         self.sub.spinOnce()
+        self.sub.spinOnce()
 
         # check the output
         output = self.get_log()
@@ -117,6 +119,7 @@ class TestPubSub(object):
         self.pub.publish('yeah_yeah', payload)
 
         self.sub.spinOnce()
+        self.sub.spinOnce()
 
         # check the output
         output = self.get_log()
@@ -134,6 +137,7 @@ class TestPubSub(object):
 
         self.synch('yeah_yeah')
         self.pub.publish('yeah_yeah', payload)
+        self.sub.spinOnce()
         self.sub.spinOnce()
 
         # check the output

--- a/dzmq/tests/test_dzmq.py
+++ b/dzmq/tests/test_dzmq.py
@@ -43,7 +43,6 @@ class TestPubSub(object):
             assert msg == payload, msg
 
         self.sub.subscribe('what_what', cb)
-        self.sub.spinOnce()
 
         self.synch('what_what')
         self.pub.publish('what_what', payload)


### PR DESCRIPTION
Remove the `SYN` message and make better use of the `SUB` message (now periodic).  Did not put it in a thread, since it relies on the poller.  Fixes #3.
